### PR TITLE
send-to-graphite modification for mrtg

### DIFF
--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -16,7 +16,7 @@
 ###################################################################
 my @STARTARGS=($0,@ARGV);
 
-@main::DEBUG=qw();
+@main::DEBUG=qw(log cfg);
 # DEBUG TARGETS
 # cfg  - watch the config file reading
 # dir  - directory mangeling
@@ -84,24 +84,6 @@ use lib "${FindBin::Bin}";
 use lib "${FindBin::Bin}${main::SL}..${main::SL}lib${main::SL}mrtg2";
 use Getopt::Long;
 use Math::BigFloat;
-
-# Module invocation and variables for sending a copy of the time series data
-# to graphite.
-use Net::Graphite;
-my $graphite;                           #use this for object
-my $sendtographite = 1;                 #turn graphite sender on/off
-my $graphitehost = "localhost";         #graphite server
-my $graphiteport = 2003;                #graphite port
-my $graphiteproto = "tcp";              #graphite protocol
-my $graphitetrace = 0;                  #send data to STDERR for debug
-my $graphitetimeout = 1;                #socket connect timeout in seconds
-my $graphiteff = 1;                     #fire & forget, if true, ignore sending errors
-my $graphiteconerr = 0;                 #if true, forward connect error to caller
-my $graphitensprefix = "m2g";           #prefix for graphite name space (m2g = mrtg-to-graphite)
-my ($graphitein,$graphiteout);          #use these to convert MRTG's in & out vars to graphite namespace
-my ($graphiterouter);
-# end mod for sending data to graphite
-
 
 # search for binaries in the bin and bin/../lib  directory
 use MRTG_lib "2.100016";
@@ -326,6 +308,11 @@ sub main {
         }
     }
 
+    # Module invocation for sending a copy of the time series data to graphite.
+    if(defined $cfg{sendtographite}) {
+      require Net::Graphite;
+    }
+
     # from our last run we kept some info about
     # the configuration of our devices around
     debug('base', "Reading Interface Config cache");
@@ -375,27 +362,6 @@ sub main {
     &demonize_me($pidfile,$cfgfile) if defined $cfg{'runasdaemon'}  and $cfg{'runasdaemon'} =~ /y/i  and $MRTG_lib::OS ne 'VMS'
     	and not (defined $cfg{'nodetach'} and $cfg{'nodetach'} =~ /y/i);
     # auto restart on die if running as demon
-
-
-    # Open the graphite socket using the vars from above
-    if($sendtographite and defined $cfg{'runasdaemon'}) {
-        $graphite = Net::Graphite->new(
-        host                  => $graphitehost,
-        port                  => $graphiteport,
-        trace                 => $graphitetrace,
-        proto                 => $graphiteproto,
-        timeout               => $graphitetimeout,
-        fire_and_forget       => $graphiteff,
-        return_connect_error  => $graphiteconerr
-      );
-      if($graphite->connect) {
-        debug('log',"successfully opened graphite socket ($graphite)\n");
-      } else {
-        debug('log',"graphite connect error: $!\n");
-      }
-    }
-
-
 
     $SIG{__DIE__} = sub {
         warn $_[0];
@@ -1023,14 +989,31 @@ sub writegraphics {
 
 
         # Send a copy of the time series data to graphite
-        if($sendtographite) {
+        if(defined $$cfg{sendtographite}) {
+          my @a = split ",",$$cfg{sendtographite};
+          my $graphite = Net::Graphite->new(
+            host                  => $a[0],
+            port                  => $a[1],
+            trace                 => 0,
+            proto                 => "tcp",
+            timeout               => 1,
+            fire_and_forget       => 1,
+            return_connect_error  => 0
+          );
+          if($graphite->connect) {
+            debug('log',"successfully opened graphite socket ($graphite)\n");
+          } else {
+            debug('log',"graphite connect error: $!\n");
+          }
+
 	  # make a copy of the router name for use in the graphite namespace
-          $graphiterouter = $router;
+          my $graphiterouter = $router;
           # periods are delimiters in the graphite namespace so change them to underscores
           $graphiterouter =~ s/_/\./g;
 	  # commas are not allowed
           $graphiterouter =~ s/,//g; #remove commas
           #set up MRTG's 'in' var naming for graphite
+          my $graphitein;
           if ($$rcfg{'legendi'}{$router}) {
             $graphitein = $$rcfg{'legendi'}{$router};
 	    # if the 'in' var contains an underscore, change to a period so graphite will delimit on it
@@ -1041,6 +1024,7 @@ sub writegraphics {
           }
 
           #set up MRTG's 'out' var naming for graphite
+          my $graphiteout;
           if ($$rcfg{'legendo'}{$router}) {
             $graphiteout = $$rcfg{'legendo'}{$router};
 	    # if the 'out' var contains an underscore, change to a period so graphite will delimit on it
@@ -1050,6 +1034,8 @@ sub writegraphics {
             $graphiteout = "out";
           }
 
+          my $graphitensprefix="m2g";
+
           # send the 'in' var data to graphite, and log it appropriately
           debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
           $graphite->send(
@@ -1057,6 +1043,7 @@ sub writegraphics {
             value => "$inlast",
             time => $time,
           );
+
           # send the 'out' var data to graphite, and log it appropriately
           debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
           $graphite->send(

--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -90,6 +90,8 @@ use MRTG_lib "2.100016";
 
 my $NOW = timestamp;
 
+my $graphiteObj;
+
 # $SNMP_Session::suppress_warnings = 2;
 use locales_mrtg "0.07";
 
@@ -991,7 +993,8 @@ sub writegraphics {
         # Send a copy of the time series data to graphite
         if(defined $$cfg{sendtographite}) {
           my @a = split ",",$$cfg{sendtographite};
-          my $graphite = Net::Graphite->new(
+          if (not $graphiteObj) { 
+            $graphiteObj = Net::Graphite->new(
             host                  => $a[0],
             port                  => $a[1],
             trace                 => 0,
@@ -999,11 +1002,12 @@ sub writegraphics {
             timeout               => 1,
             fire_and_forget       => 1,
             return_connect_error  => 0
-          );
-          if($graphite->connect) {
-            debug('log',"successfully opened graphite socket ($graphite)\n");
-          } else {
-            debug('log',"graphite connect error: $!\n");
+            );
+            if($graphiteObj->connect) {
+              debug('log',"successfully opened graphite socket ($graphiteObj)\n");
+            } else {
+              debug('log',"graphite connect error: $!\n");
+            }
           }
 
 	  # make a copy of the router name for use in the graphite namespace
@@ -1038,7 +1042,7 @@ sub writegraphics {
 
           # send the 'in' var data to graphite, and log it appropriately
           debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
-          $graphite->send(
+          $graphiteObj->send(
             path => "$graphitensprefix.$graphiterouter.$graphitein",
             value => "$inlast",
             time => $time,
@@ -1046,7 +1050,7 @@ sub writegraphics {
 
           # send the 'out' var data to graphite, and log it appropriately
           debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
-          $graphite->send(
+          $graphiteObj->send(
             path => "$graphitensprefix.$graphiterouter.$graphiteout",
             value => "$outlast",
             time => $time,

--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -16,7 +16,7 @@
 ###################################################################
 my @STARTARGS=($0,@ARGV);
 
-@main::DEBUG=qw(log cfg);
+@main::DEBUG=qw();
 # DEBUG TARGETS
 # cfg  - watch the config file reading
 # dir  - directory mangeling

--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -85,6 +85,24 @@ use lib "${FindBin::Bin}${main::SL}..${main::SL}lib${main::SL}mrtg2";
 use Getopt::Long;
 use Math::BigFloat;
 
+# Module invocation and variables for sending a copy of the time series data
+# to graphite.
+use Net::Graphite;
+my $graphite;                           #use this for object
+my $sendtographite = 1;                 #turn graphite sender on/off
+my $graphitehost = "localhost";         #graphite server
+my $graphiteport = 2003;                #graphite port
+my $graphiteproto = "tcp";              #graphite protocol
+my $graphitetrace = 0;                  #send data to STDERR for debug
+my $graphitetimeout = 1;                #socket connect timeout in seconds
+my $graphiteff = 1;                     #fire & forget, if true, ignore sending errors
+my $graphiteconerr = 0;                 #if true, forward connect error to caller
+my $graphitensprefix = "m2g";           #prefix for graphite name space (m2g = mrtg-to-graphite)
+my ($graphitein,$graphiteout);          #use these to convert MRTG's in & out vars to graphite namespace
+my ($graphiterouter);
+# end mod for sending data to graphite
+
+
 # search for binaries in the bin and bin/../lib  directory
 use MRTG_lib "2.100016";
 
@@ -357,6 +375,27 @@ sub main {
     &demonize_me($pidfile,$cfgfile) if defined $cfg{'runasdaemon'}  and $cfg{'runasdaemon'} =~ /y/i  and $MRTG_lib::OS ne 'VMS'
     	and not (defined $cfg{'nodetach'} and $cfg{'nodetach'} =~ /y/i);
     # auto restart on die if running as demon
+
+
+    # Open the graphite socket using the vars from above
+    if($sendtographite and defined $cfg{'runasdaemon'}) {
+        $graphite = Net::Graphite->new(
+        host                  => $graphitehost,
+        port                  => $graphiteport,
+        trace                 => $graphitetrace,
+        proto                 => $graphiteproto,
+        timeout               => $graphitetimeout,
+        fire_and_forget       => $graphiteff,
+        return_connect_error  => $graphiteconerr
+      );
+      if($graphite->connect) {
+        debug('log',"successfully opened graphite socket ($graphite)\n");
+      } else {
+        debug('log',"graphite connect error: $!\n");
+      }
+    }
+
+
 
     $SIG{__DIE__} = sub {
         warn $_[0];
@@ -981,6 +1020,53 @@ sub writegraphics {
         }
         my $e = RRDs::error(); 
         warn "$NOW: ERROR: Cannot update $dotrrd with '$time:$inlast:$outlast' $e\n" if ($e);
+
+
+        # Send a copy of the time series data to graphite
+        if($sendtographite) {
+	  # make a copy of the router name for use in the graphite namespace
+          $graphiterouter = $router;
+          # periods are delimiters in the graphite namespace so change them to underscores
+          $graphiterouter =~ s/_/\./g;
+	  # commas are not allowed
+          $graphiterouter =~ s/,//g; #remove commas
+          #set up MRTG's 'in' var naming for graphite
+          if ($$rcfg{'legendi'}{$router}) {
+            $graphitein = $$rcfg{'legendi'}{$router};
+	    # if the 'in' var contains an underscore, change to a period so graphite will delimit on it
+            $graphitein =~ s/_/\./g;
+          } else {
+	    # if legendi is not specified, just use 'in'
+            $graphitein = "in";
+          }
+
+          #set up MRTG's 'out' var naming for graphite
+          if ($$rcfg{'legendo'}{$router}) {
+            $graphiteout = $$rcfg{'legendo'}{$router};
+	    # if the 'out' var contains an underscore, change to a period so graphite will delimit on it
+            $graphiteout =~ s/_/\./g;
+          } else {
+	    # if legendo is not specified, just use 'out'
+            $graphiteout = "out";
+          }
+
+          # send the 'in' var data to graphite, and log it appropriately
+          debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
+          $graphite->send(
+            path => "$graphitensprefix.$graphiterouter.$graphitein",
+            value => "$inlast",
+            time => $time,
+          );
+          # send the 'out' var data to graphite, and log it appropriately
+          debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
+          $graphite->send(
+            path => "$graphitensprefix.$graphiterouter.$graphiteout",
+            value => "$outlast",
+            time => $time,
+          );
+        }
+        # done sending to graphite for this iteration
+
 
 	if ( $RRDs::VERSION < 1.2 ){
              # get the rrdtool-processed values back from rrdtool

--- a/src/doc/mrtg-reference.pod
+++ b/src/doc/mrtg-reference.pod
@@ -520,6 +520,76 @@ See "Extended Host Name Syntax" below for complete target definition syntax
 information.
 
 
+=head2 SendToGraphite
+
+If you want to send a copy of the collected data into a Graphite database in addition
+to storing it in the RRDfile, you can provide your Graphite database name/ip and port
+number here. 
+
+This requires the Net::Graphite perl module which is available from CPAN.
+
+Examples:
+ # If your Graphite receiver is running on the same host as the MRTG daemon and using the default port 
+ SendToGraphite: 127.0.0.1,2003
+
+ # If your Graphite receiver is running on 192.168.100.50 port 5000
+ SendToGraphite: 192.168.100.50,5000
+
+ # If your Graphite receiver is running on graphite.mydomain.com port 2003
+ SendToGraphite: graphite.mydomain.com,2003
+
+Graphite's namespace has a number of restrictions on what characters are 
+allowed. The SendToGraphite functionality makes an attempt to convert the MRTG 
+target name and, if specified, the Legendi and Legendo values to Graphite namespace
+friendly values. Specifically, the following conversion rules apply:
+
+=item *
+Underscores in the target_name are converted to periods which are Graphite namespace delimiters.
+=item *
+Comma characters are not allowed so they are removed.
+=item *
+The string "m2g" for MRTG to Graphite is prepended onto the Graphite namespace variable.
+
+Example MRTG target to Graphite namespace conversion:
+ # Our MRTG target name from mrtg.cfg is as follows
+ Target[switch_GigabitEthernet0_5]: \GigabitEthernet0/5:public1@switch:::::2
+
+After the conversion you will end up with these Graphite namespace values
+
+ m2g.switch.gigabitethernet0.5.in
+ m2g.switch.gigabitethernet0.5.out
+
+Next is a more complicated example because Legendi and Legendo are in use to denote min and max
+voltage values that pertain to some APC UPS SNMP OIDs
+ # Target, Legendi, and Legendo are specified in mrtg.cfg as follows
+ Target[apc_minmaxline]: 1.3.6.1.4.1.318.1.1.1.3.2.3.0&1.3.6.1.4.1.318.1.1.1.3.2.2.0:public@apc:
+ LegendI[apc_minmaxline]: upsAdvInputMinLineVoltage
+ LegendO[apc_minmaxline]: upsAdvInputMaxLineVoltage
+
+After the conversion you will end up with these Graphite namespace values
+ m2g.apc.minmaxline.upsAdvInputMinLineVoltage
+ m2g.apc.minmaxline.upsAdvInputMaxLineVoltage
+
+
+If you don't see the data showing up in Graphite, chances are there are invalid characters in
+the namespace. To debug this, use the DEBUG=qw(log) directive at the top of the MRTG script 
+to find out what is happening with the MRTG to Graphite namespace conversion. 
+
+DEBUG=qw(log) will generate some output similar to what appears below
+
+ 2016-10-13 06:08:39 -- --log: RRDs::update(/var/www/mrtg/switch/switch_gigabitethernet0_5.rrd, '1476356919:2738746035:2927936327')
+ 2016-10-13 06:08:39 -- --log: graphite->send(m2g.switch.gigabitethernet0.5.in,2738746035,1476356919)
+
+ 2016-10-13 06:08:39 -- --log: graphite->send(m2g.switch.gigabitethernet0.5.out,2927936327,1476356919)
+
+ 2016-10-13 06:09:25 -- --log: RRDs::update(/var/www/mrtg/apc/apc_minmaxline.rrd, '1476356965:122:123')
+ 2016-10-13 06:09:25 -- --log: graphite->send(m2g.apc.minmaxline.upsAdvInputMinLineVoltage,122,1476356965)
+
+ 2016-10-13 06:09:25 -- --log: graphite->send(m2g.apc.minmaxline.upsAdvInputMaxLineVoltage,123,1476356965)
+
+If the MRTG log output looks reasonable, then take a look at Graphite's carbon-cache logs.
+
+
 =head1 PER TARGET CONFIGURATION
 
 Each monitoring target must be identified by a unique name. This

--- a/src/doc/mrtg-reference.pod
+++ b/src/doc/mrtg-reference.pod
@@ -529,6 +529,7 @@ number here.
 This requires the Net::Graphite perl module which is available from CPAN.
 
 Examples:
+
  # If your Graphite receiver is running on the same host as the MRTG daemon and using the default port 
  SendToGraphite: 127.0.0.1,2003
 
@@ -544,13 +545,22 @@ target name and, if specified, the Legendi and Legendo values to Graphite namesp
 friendly values. Specifically, the following conversion rules apply:
 
 =item *
+
 Underscores in the target_name are converted to periods which are Graphite namespace delimiters.
+
 =item *
+
 Comma characters are not allowed so they are removed.
+
 =item *
+
 The string "m2g" for MRTG to Graphite is prepended onto the Graphite namespace variable.
 
+
+=back
+
 Example MRTG target to Graphite namespace conversion:
+
  # Our MRTG target name from mrtg.cfg is as follows
  Target[switch_GigabitEthernet0_5]: \GigabitEthernet0/5:public1@switch:::::2
 
@@ -561,12 +571,14 @@ After the conversion you will end up with these Graphite namespace values
 
 Next is a more complicated example because Legendi and Legendo are in use to denote min and max
 voltage values that pertain to some APC UPS SNMP OIDs
+
  # Target, Legendi, and Legendo are specified in mrtg.cfg as follows
  Target[apc_minmaxline]: 1.3.6.1.4.1.318.1.1.1.3.2.3.0&1.3.6.1.4.1.318.1.1.1.3.2.2.0:public@apc:
  LegendI[apc_minmaxline]: upsAdvInputMinLineVoltage
  LegendO[apc_minmaxline]: upsAdvInputMaxLineVoltage
 
 After the conversion you will end up with these Graphite namespace values
+
  m2g.apc.minmaxline.upsAdvInputMinLineVoltage
  m2g.apc.minmaxline.upsAdvInputMaxLineVoltage
 


### PR DESCRIPTION
I have been working on modifying MRTG to send a copy of the time series data it collects to
Graphite (https://github.com/graphite-project) in addition to storing it in RRD files. I am
interested in doing this because I have a large, customized MRTG installation that collects
many metrics from many devices and it would be nice to work with that time series data via
one of the many Graphite front-ends such as Grafana (https://github.com/grafana/grafana)
without having to implement a whole new SNMP data collection system. With this in mind I
have modified mrtg 2.17.4 to use the Net::Graphite perl module
(http://search.cpan.org/~slanning/Net-Graphite-0.14/) to open a TCP socket to my Graphite
server on startup and send a copy of each collected metric and the associated timestamp to
Graphite after the calls to RRDs::update.

So far it works pretty well. The most difficult task was converting the relevant MRTG
config file directives (things like $$rcfg{'legendi'}{$router} and
$$rcfg{'legendo'}{$router}) into meaningful graphite name space values. This took some
experimentation because periods are graphite namespace delimiters, and spaces along with
other special characters are not allowed in the graphite namespace at all. In some cases I
had to go back and modify my custom MRTG cfg builder scripts and MRTG template files to not
use periods and special characters.

If you decide to try it out keep these things in mind...
-I strongly suggest using a graphite docker image unless you already have a
functioning graphite instance.
-The same can be said for Grafana - use the docker image if you are looking for a
fancier Graphite front end.
-You will need to specify your graphite server name/ip around line 92 where it says 
my $graphitehost = "localhost";
unless you're running it on the same host as your mrtg poller.
-Ideally the graphite variable assignments in lines 90 - 101 should be cfg file
parms but so far this is just experimentation and I haven't had time to work on it
beyond the proof of concept phase.
-This only works in daemon mode so if your config files don't have RunAsDaemon:Yes in
them you're out of luck. Sorry.
-If nothing shows up at your graphite server, edit the mrtg script around line 19 and specify DEBUG=qw(log). This is useful for troubleshooting graphite TCP socket open problems and the
MRTG-config-file-var-to-graphite-namespace conversions. This debug statement will
cause your MRTG log files to get big so be sure to set DEBUG=qw() after things are working correctly.
-So far I have only run this on linux. I don't know if it will work on Windows or
anything else.
-You will need to install Net::Graphite from CPAN, so from your linux prompt...
perl -MCPAN -e shell
install Net::Graphite
~~-If the TCP socket from the MRTG server to the Graphite server goes away for some
reason (connectivity problems, graphite shutdown, etc) the MRTG daemon will die.
This is clearly a bad implementation on my part but I haven't had time to look at
it. Ideally MRTG will continue to run and update the RRD files if the Graphite
socket goes away and gracefully reconnect when the Graphite server is reachable
again.~~
This should be fixed now. The MRTG daemon should live through a graphite disconnect, continue updating the RRD files, and gracefully reconnect when the graphite server is reachable again.
