### PR TITLE
Remove an incorrect free in rateup

### DIFF
--- a/src/src/rateup.c
+++ b/src/src/rateup.c
@@ -1132,10 +1132,13 @@ image (file, maxvi, maxvo, maxx, maxy, xscale, yscale, growright, step, bits,
   gdImageDestroy (brush_outp);
   free (lhist);
   free (graph_label);
-  if (kMG) {
+  /* By commenting out the next 4 lines, short_si will leak exactly one copy of kMG, but
+     otherwise the kMG values for the weekly/monthly/yearly graphs are wrong.  This should
+     also fix the crash reported in GitHub issue #3. */
+  /* if (kMG) {
     free(short_si);
     short_si = short_si_def;
-  }
+  } */
 
 #ifdef WIN32
   /* got to remove the target under win32


### PR DESCRIPTION
Commenting out lines 1135 - 1138 prevents `image()` from stomping on a shallow copy of kMG.  The stomping leads to a crash under OS X, as reported in upstream #3, and causes the units on weekly/monthly/yearly graphs to be wrong under more forgiving operating systems.