### PR TITLE
Modifications to the send to graphite code

### DIFF
--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -1040,6 +1040,7 @@ sub writegraphics {
 
           my $graphitensprefix="m2g";
 
+          # verify that the 'in' value is numeric, and send to graphite
           if($inlast =~ /\d+/) {
             # send the 'in' var data to graphite, and log it appropriately
             debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
@@ -1052,7 +1053,8 @@ sub writegraphics {
             debug('log', "WARNING - skipped graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time) because value ($inlast) is non-numeric\n");
           }
 
-          if($inlast =~ /\d+/) {
+          # verify that the 'out' value is numeric, and send to graphite
+          if($outlast =~ /\d+/) { 
             # send the 'out' var data to graphite, and log it appropriately
             debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
             $graphiteObj->send(

--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -1040,8 +1040,8 @@ sub writegraphics {
 
           my $graphitensprefix="m2g";
 
-          # verify that the 'in' value is numeric, and send to graphite
-          if($inlast =~ /\d+/) {
+          # verify that the 'in' value is numeric (ints, floats, +, -) , and send to graphite
+          if($inlast =~ /^[+-]?([0-9]*[.])?[0-9]+$/) {
             # send the 'in' var data to graphite, and log it appropriately
             debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
             $graphiteObj->send(
@@ -1053,8 +1053,8 @@ sub writegraphics {
             debug('log', "WARNING - skipped graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time) because value ($inlast) is non-numeric\n");
           }
 
-          # verify that the 'out' value is numeric, and send to graphite
-          if($outlast =~ /\d+/) { 
+          # verify that the 'out' value is numeric (ints, floats, +, -) , and send to graphite
+          if($outlast =~ /^[+-]?([0-9]*[.])?[0-9]+$/) { 
             # send the 'out' var data to graphite, and log it appropriately
             debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
             $graphiteObj->send(

--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -1040,23 +1040,32 @@ sub writegraphics {
 
           my $graphitensprefix="m2g";
 
-          # send the 'in' var data to graphite, and log it appropriately
-          debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
-          $graphiteObj->send(
-            path => "$graphitensprefix.$graphiterouter.$graphitein",
-            value => "$inlast",
-            time => $time,
-          );
+          if($inlast =~ /\d+/) {
+            # send the 'in' var data to graphite, and log it appropriately
+            debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time)\n");
+            $graphiteObj->send(
+              path => "$graphitensprefix.$graphiterouter.$graphitein",
+              value => "$inlast",
+              time => $time,
+            );
+          } else {
+            debug('log', "WARNING - skipped graphite->send($graphitensprefix.$graphiterouter.$graphitein,$inlast,$time) because value ($inlast) is non-numeric\n");
+          }
 
-          # send the 'out' var data to graphite, and log it appropriately
-          debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
-          $graphiteObj->send(
-            path => "$graphitensprefix.$graphiterouter.$graphiteout",
-            value => "$outlast",
-            time => $time,
-          );
+          if($inlast =~ /\d+/) {
+            # send the 'out' var data to graphite, and log it appropriately
+            debug('log', "graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time)\n");
+            $graphiteObj->send(
+              path => "$graphitensprefix.$graphiterouter.$graphiteout",
+              value => "$outlast",
+              time => $time,
+            );
+          } else {
+            debug('log', "WARNING - skipped graphite->send($graphitensprefix.$graphiterouter.$graphiteout,$outlast,$time) because value ($outlast) is non-numeric\n");
+          }
         }
         # done sending to graphite for this iteration
+
 
 
 	if ( $RRDs::VERSION < 1.2 ){


### PR DESCRIPTION
I've been using this in production for a while now. It works well - I have about 400 MRTG daemons sending 130,000 metrics into Graphite at 1 minute intervals.

One problem I encountered is that when MRTG runs into a collection problem (invalid OID, etc) it ends up trying to send a "U" value into Graphite. This just pollutes Graphite's listener.log with error messages. So this modification checks that the value is numeric before sending. If that value is non-numeric then the send is skipped and if debug(log) is in use a warning message is logged.
