### PR TITLE
Fix mrtg-traffic-sum incorrectly ignores '--man' option

### DIFF
--- a/src/bin/mrtg-traffic-sum
+++ b/src/bin/mrtg-traffic-sum
@@ -58,7 +58,7 @@ sub mailout($$);
 sub main()
 {
     # parse options
-    GetOptions(\%opt, 'min=i','help|h', 'catch=s', 'email=s','version','range=s','units=s') or exit(1);
+    GetOptions(\%opt, 'min=i','help|h', 'catch=s', 'email=s','version','range=s','units=s','man') or exit(1);
     if($opt{help})     { pod2usage(1) }
     if($opt{man})      { pod2usage(-exitstatus => 0, -verbose => 2) }
     if($opt{version})  { print "mrtg-traffic-sum $Revision\n"; exit(0) }


### PR DESCRIPTION
mrtg-traffic-sum should show man page incorporated in the script when executed with --man option. It was failing with:
```console
# mrtg-traffic-sum --man
Unknown option: man
```
This commit fixes the issue.