### PR TITLE
Fix lock and move cache

### DIFF
--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -241,12 +241,15 @@ sub main {
     # so we lock on the cfg file. Nothing fancy, just a lockfile
 
     $lockfile = $opts{"lock-file"} || $lockfile;
+	my @cfgfile = split(/\//, $cfgfile);
 
     if (! defined $lockfile) {
-        $lockfile = $cfgfile."_l";
+#DEB        $lockfile = $cfgfile."_l";
+       $lockfile = "/var/lock/mrtg/" . join('_', @cfgfile) . "_l";
     }
     if (! defined $templock) {
         $templock = $lockfile."_" . $$ ;
+#DEB        $templock = "/var/lock/mrtg/" . join('_', @cfgfile) . "_l_" . $$ ;
     }
 
     debug('base', "Creating Lockfiles $lockfile,$templock");
@@ -323,6 +326,8 @@ sub main {
         $confcachefile = $cfgfile;
         $confcachefile  =~ s/\.[^.\/]+$//;
         $confcachefile .= ".ok";
+        my @cachefile = split(/\//, $cfgfile);
+        $confcachefile = "/var/lib/mrtg/" . join('_', @cachefile);
     }
     my $confcache = readconfcache($confcachefile);
 


### PR DESCRIPTION
This is a patch from Debian.

Original name: 010-mrtg_lock_temp_cache_files_fixups.patch
URL: https://salsa.debian.org/eriberto/mrtg/-/blob/debian/master/debian/patches/010-mrtg_lock_temp_cache_files_fixups.patch

The headers from this patch are available below:

Description: This patch contains several bugs fixes, f.e. #67327, #41806,
             #87950, #106415, #206073, #155934 - but given digging so late
             in the past is not easy at all, I wasn't sure to split it further
             (message from Sandro Tosi, 2011-08-15).

Description: Move the mrtg lock files from /etc to /var/lock/mrtg
Author: Dermot Bradley <bradley@debian.org>
Bug-Debian: https://bugs.debian.org/41806
Last-Update: 1999-07-26

Description: Fix missing locking code
Author: Peter Gervai <grin@tolna.net>
Bug-Debian: https://bugs.debian.org/106415
Last-Update: 2001-07-25

Description: Move MRTG config file cache into /var/lib/mrtg
Author: Michael-John Turner <mj@debian.org>
Bug-Debian: https://bugs.debian.org/67327
Last-Update: 2001-09-08

Description: Fix --lock-file option problem
Author: Shiju p. Nair <shiju@infovillage.net>
Bug-Debian: https://bugs.debian.org/206073
Last-Update: 2004-02-13