### PR TITLE
Use gawk because mawk doesn't have strftime

### DIFF
--- a/src/contrib/mrtgrq/make-mrtg.cfg.awk
+++ b/src/contrib/mrtgrq/make-mrtg.cfg.awk
@@ -37,7 +37,7 @@ END{
 #
  for ( k = 1; k < lines; k++ ){
 #  print array[k, 1]"\t"array[k, 3]"\t"array[k, 4] > mrtg_mrtgrq_cfg
-   print ("Target[" array[k, 1] "]: `echo | awk '{ print \"" array[k, 3]"\\n" array[k, 4]"\\n..., last check on: " strftime("%c %Z", startdate) "\\n" array[k, 1] "@cfrcta.ro\\n\"; exit }'`") > mrtg_mrtgrq_cfg
+   print ("Target[" array[k, 1] "]: `echo | gawk '{ print \"" array[k, 3]"\\n" array[k, 4]"\\n..., last check on: " strftime("%c %Z", startdate) "\\n" array[k, 1] "@cfrcta.ro\\n\"; exit }'`") > mrtg_mrtgrq_cfg
    print ("Title[" array[k, 1] "]: Diskspace Quota Report For " array[k, 1] "@cfrcta.ro") > mrtg_mrtgrq_cfg
    print ("MaxBytes[" array[k, 1] "]: " array[k, 4]) > mrtg_mrtgrq_cfg
    print ("AbsMax[" array[k, 1] "]: " int(array[k, 4]*1.1)) > mrtg_mrtgrq_cfg
@@ -49,7 +49,7 @@ END{
    print ("   <TR><TD CLASS=\"ptb\">Maintainer:</TD><TD CLASS=\"pth\"><B>" mrtgrq_maintainer_email "</B></TD></TR>") > mrtg_mrtgrq_cfg
    print ("   <TR><TD CLASS=\"ptb\">Last Checked On:</TD><TD CLASS=\"pth\"><B>" strftime("%c %Z", startdate) "</B></TD></TR>") > mrtg_mrtgrq_cfg
    print ("  </TABLE>") > mrtg_mrtgrq_cfg
-   print ("Supress[" array[k, 1] "]: y") > mrtg_mrtgrq_cfg
+   print ("Suppress[" array[k, 1] "]: y") > mrtg_mrtgrq_cfg
    print ("LegendI[" array[k, 1] "]: used") > mrtg_mrtgrq_cfg
    print ("LegendO[" array[k, 1] "]: ") > mrtg_mrtgrq_cfg
    print ("Legend1[" array[k, 1] "]: used") > mrtg_mrtgrq_cfg

--- a/src/contrib/net-hosts/make-mrtg.cfg.awk
+++ b/src/contrib/net-hosts/make-mrtg.cfg.awk
@@ -154,7 +154,7 @@ function myfun(f_rindex, f_index, f_name, f_olddate, f_last_state)
   print startcell imgup endcell > (mrtg_var_WorkDir "/internet.html")
   print startcell strftime("%c %Z", datew) endcell > (mrtg_var_WorkDir "/internet.html") 
   print endrow > (mrtg_var_WorkDir "/internet.html")
-  print "Target[" f_name "]: `echo | awk '{ print \"1\\n1\\n..., last changed on: " strftime("%c %Z", datew) "\\n" array[f_index, 1] "\\n\"; exit }'`" > mrtg_nethosts_cfg
+  print "Target[" f_name "]: `echo | gawk '{ print \"1\\n1\\n..., last changed on: " strftime("%c %Z", datew) "\\n" array[f_index, 1] "\\n\"; exit }'`" > mrtg_nethosts_cfg
  }
  else {
   statew = 0
@@ -190,7 +190,7 @@ function myfun(f_rindex, f_index, f_name, f_olddate, f_last_state)
   print "   <TR><TD CLASS=\"ptb\">IP:</TD><TD CLASS=\"pth\"><B>" f_name " (" array[f_index, 1] ")</B></TD></TR>" > mrtg_nethosts_cfg
   print "   <TR><TD CLASS=\"ptb\">Last Changed On:</TD><TD CLASS=\"pth\"><B>" strftime("%c %Z", datew) "</B></TD></TR>" > mrtg_nethosts_cfg
   print "  </TABLE>" > mrtg_nethosts_cfg
-  print "Supress[" f_name "]: y" > mrtg_nethosts_cfg
+  print "Suppress[" f_name "]: y" > mrtg_nethosts_cfg
   print "LegendI[" f_name "]: used" > mrtg_nethosts_cfg
   print "LegendO[" f_name "]: " > mrtg_nethosts_cfg
   print "Legend1[" f_name "]: used" > mrtg_nethosts_cfg

--- a/src/contrib/net-hosts/net-hosts
+++ b/src/contrib/net-hosts/net-hosts
@@ -11,7 +11,7 @@ NETHOSTST_INTERNET_PATH="/usr/local/mrtg/contrib/net-hosts"
 NETHOSTST_AWK_FILE="/usr/local/mrtg/contrib/net-hosts/make-mrtg.cfg.awk"
 ##
 ##
-/bin/cat $NETHOSTST_INTERNET_PATH/internet | /bin/awk -F: '{print $1}' | /usr/sbin/fping | /bin/awk -f $NETHOSTST_AWK_FILE
+/bin/cat $NETHOSTST_INTERNET_PATH/internet | /usr/bin/gawk -F: '{print $1}' | /usr/sbin/fping | /usr/bin/gawk -f $NETHOSTST_AWK_FILE
 ##
 ##
 #####################################################################################################


### PR DESCRIPTION
This is a patch from Debian.

Original name: 020-bts113894_use_gawk.patch
URL: https://salsa.debian.org/eriberto/mrtg/-/blob/debian/master/debian/patches/020-bts113894_use_gawk.patch

The headers from this patch are available below:

Description: uses gawk because mawk doesn't have strftime
Author: Theodore Alexandrov <theo@pdmi.ras.ru>
Reviewed-By: Sandro Tosi <morph@debian.org>
Bug-Debian: https://bugs.debian.org/113894
Lats-Update: 2009-11-12