### PR TITLE
Avoid to include global options by default

### DIFF
--- a/src/bin/cfgmaker
+++ b/src/bin/cfgmaker
@@ -323,7 +323,8 @@ sub GenConf ($$$$) {
     my $conf = "# Created by \n# $$opt{fullcmd}\n\n";
 
     # print global options
-    $conf .= <<ECHO;
+    unless (defined $$opt{'nodefaultglobal'}) {
+      $conf .= <<ECHO;
 
 ### Global Config Options
 
@@ -339,6 +340,7 @@ sub GenConf ($$$$) {
 # Options[_]: growright, bits
 
 ECHO
+}
 
     # Add EnableIPv6 option to configuration file
     if ($$opt{'enable-ipv6'} == 1) {
@@ -1260,6 +1262,7 @@ sub options ($$) {
         'version',
         'output=s',
         'global=s@',
+        'nodefaultglobal',
         'enable-ipv6',
         'enablesnmpv3',
         'use-16bit',
@@ -1630,6 +1633,8 @@ cfgmaker [options] [community@]router [[options] [community@]router ...]
                    (Experimental, under development, might change)
 
  --global "x: a"   add global config entries
+
+ --nodefaultglobal do not include default global settings
 
  --no-down         do not look at admin or opr status of interfaces
 


### PR DESCRIPTION
Personally, I don't know if this patch will be accepted. If not, I can keep it
on Debian. The original bug in Debian said:

 When generating configuration files in an automated fashion (including
 other .cfg files), the global options inserted by cfgmaker. Please
 include the included patch which adds a "nodefaultglobal" option to
 cfgmaker.

This is a patch from Debian.

Original name: 050-bts167107_nodefaultglobal.patch
URL: https://salsa.debian.org/eriberto/mrtg/-/blob/debian/master/debian/patches/050-bts167107_nodefaultglobal.patch

The header from this patch is available below:

Description: added 'nodefaultglobal' option
             This will avoid to include global options by default.
Author: Hilko Bengen <bengen@vdst-ka.inka.de>
Reviewed-By: Sandro Tosi <morph@debian.org>
Bug-Debian: https://bugs.debian.org/167107
Last-Update: 2009-11-12