### PR TITLE
Remove files generated by the build process and forgotten when cleaning

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -6,6 +6,7 @@ VER=2.17.8
 .SUFFIXES: .c .o .pl .pm .pod .man .1 .txt
 
 prefix = @prefix@
+datarootdir = @datarootdir@
 exec_prefix = @exec_prefix@
 bindir = @bindir@
 libdir = @libdir@


### PR DESCRIPTION
This PR removes forgotten files and it will allow the MRTG to build twice in Debian.