### PR TITLE
Remove an orphan symlink

### DIFF
--- a/src/doc/mrtg-mailer.pod
+++ b/src/doc/mrtg-mailer.pod
@@ -1,1 +1,0 @@
-../bin/mrtg-mailer


### PR DESCRIPTION
This is a symlink pointing to a non-existent file.