### PR TITLE
Make ifref default to name in cfgmaker

### DIFF
--- a/src/CHANGES
+++ b/src/CHANGES
@@ -1,3 +1,8 @@
+Changes 2.17.9, 2021-??-??
+--------------------------
+From: Leo Iannacone <l3on@ubuntu.com>
+* make ifref default to name in cfgmaker
+
 Changes 2.17.8, 2021-08-05
 --------------------------
 From: Martin Sechny, shenk.sk

--- a/src/bin/cfgmaker
+++ b/src/bin/cfgmaker
@@ -672,7 +672,11 @@ ECHO
                         $if_ok = 0;
                     }
                 } else {
-                    $if_ref = $ifindex;
+                    if ($$i{Name}) {
+                        $if_ref = "#".$$i{Name};
+                    } else {
+                        $if_ref = $ifindex;
+                    }
                 }
 
                 # generate Target name
@@ -1585,11 +1589,11 @@ cfgmaker [options] [community@]router [[options] [community@]router ...]
 
 =head1 OPTIONS
 
- --ifref=nr    interface references by Interface Number (default)
- --ifref=ip                     ... by Ip Address
+ --ifref=name      interface references by Interface Name (default)
+ --ifref=ip                         ... by Ip Address
  --ifref=eth                        ... by Ethernet Number
  --ifref=descr                      ... by Interface Description
- --ifref=name                       ... by Interface Name
+ --ifref=nr                         ... by Interface Number
  --ifref=type                       ... by Interface Type
                 You may also use multiple options separated by commas,
                in which case the first available one is used:


### PR DESCRIPTION
This is a patch from Ubuntu to Debian.

Author: Leo Iannacone <l3on@ubuntu.com>
URL: https://bugs.debian.org/655097