### PR TITLE
Add new options to systemd conf file

### DIFF
--- a/src/contrib/debian-systemd/mrtg.init
+++ b/src/contrib/debian-systemd/mrtg.init
@@ -31,7 +31,7 @@ RETVAL=0
 start() {
 	if [ ! -e $PIDFILE ]
 	then
-	    WORKDIR=$(cat ${CONFIG} | grep WorkDir | cut -d: -f2 | tr -d " ")
+	    WORKDIR=$(cat ${CONFIG} | grep -i WorkDir | cut -d: -f2 | tr -d " ")
 	    if [ -z ${WORKDIR} ]
 	    then
 		echo "ERROR: WorkDir not defined in config file"

--- a/src/contrib/debian-systemd/mrtg.service
+++ b/src/contrib/debian-systemd/mrtg.service
@@ -9,9 +9,12 @@ Documentation=https://oss.oetiker.ch/mrtg/doc/index.en.html
 Environment=LANG=C
 ExecStart=/usr/bin/mrtg --daemon --fhs --user=mrtg
 KillMode=process
+PIDFile=/run/mrtg/mrtg.pid
 PrivateTmp=yes
 ReadOnlyDirectories=/etc
+RuntimeDirectory=mrtg
 Type=forking
+User=mrtg
 
 [Install]
 WantedBy=multi-user.target

--- a/src/contrib/debian-systemd/mrtg.service
+++ b/src/contrib/debian-systemd/mrtg.service
@@ -9,10 +9,14 @@ Documentation=https://oss.oetiker.ch/mrtg/doc/index.en.html
 Environment=LANG=C
 ExecStart=/usr/bin/mrtg --daemon --fhs --user=mrtg
 KillMode=process
+LogsDirectory=mrtg
+LogsDirectoryMode=0750
 PIDFile=/run/mrtg/mrtg.pid
 PrivateTmp=yes
 ReadOnlyDirectories=/etc
 RuntimeDirectory=mrtg
+StateDirectory=mrtg
+StateDirectoryMode=0750
 Type=forking
 User=mrtg
 


### PR DESCRIPTION
     - Added PIDFile option, as recommended by SYSTEMD.SERVICE(5).
     - Added User option, to automatically populate environment variables like
       USER and HOME. Suggested by Norman Rasmussen in Debian bug #998158.
     - Added RuntimeDirectory option to automatically create /run/mrtg/. This
       option is required while using the User option.

In init file, Ignore case for WorkDir because MRTG also ignores this.
