### PR TITLE
Fix a warning about ignoring return value of fgets

### DIFF
--- a/src/CHANGES
+++ b/src/CHANGES
@@ -19,6 +19,7 @@ From: Andrey Tarasov <kochen@vk.com>
 
 From: youpong
 * remove unused variables from rateup.c
+* stop ignoring return value of function fgets
 
 From: Hilko Bengen <bengen@vdst-ka.inka.de>
 * avoid to include global options by default

--- a/src/src/rateup.c
+++ b/src/src/rateup.c
@@ -1247,9 +1247,8 @@ readhist (file)
       cur = last.time;
       x = histvalid = 0;
       hist = history;
-      while (!feof (fi))
+      while (fgets (buf, 256, fi) != NULL)
 	{
-	  fgets (buf, 256, fi);
 	  if (sscanf (buf, "" LLD " " LLD " " LLD " " LLD " " LLD "",
 		      &rd[0], &rd[1], &rd[2], &rd[3], &rd[4]) < 5)
 	    {


### PR DESCRIPTION
ISSUE #41
---
Use a return value of `fgets()` to reduce warnings.