### PR TITLE
Add install-sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rateup.exe
 config.h
 config.log
 config.status
+install-sh
 *.1
 *.gz
 *.o


### PR DESCRIPTION
The install-sh is a file created via autoreconf. Consequently, changes
in its content should be ignored.