### PR TITLE
Fix issue #74

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -26,7 +26,11 @@ jobs:
            make
            make doc
            sudo make install
-    - name: basic_test_mrtg
+    - name: unit_test
+      run: |
+           cd src
+           prove
+    - name: functional_test
       run: |
            mkdir test-mrtg
            cd test-mrtg

--- a/src/CHANGES
+++ b/src/CHANGES
@@ -2,6 +2,7 @@ Changes 2.17.11, 2022-??-??
 ---------------------------
 From: youpong
 * stop making an orphan symlink (mrtg-mailer.pod)
+* fix Brazilian translation(Issue #74)
 
 Changes 2.17.10, 2022-01-19
 ---------------------------

--- a/src/bin/mrtg
+++ b/src/bin/mrtg
@@ -93,7 +93,7 @@ my $NOW = timestamp;
 my $graphiteObj;
 
 # $SNMP_Session::suppress_warnings = 2;
-use locales_mrtg "0.07";
+use locales_mrtg "0.08";
 
 # Do not Flash Console Windows for the forked rateup process 
 BEGIN {

--- a/src/t/translation.t
+++ b/src/t/translation.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use FindBin;
+use lib "${FindBin::Bin}/../lib/mrtg2";
+use locales_mrtg "0.07";
+
+my $LOC = $lang2tran::LOCALE{"brazilian"};
+unlike( &$LOC("The statistics were last updated <strong>Ter&ccedil;a, 26 de Outubro"),
+        qr/Sa&iacute;ubro/, "Issue #74");
+

--- a/src/t/translation.t
+++ b/src/t/translation.t
@@ -5,7 +5,7 @@ use Test::More tests => 1;
 
 use FindBin;
 use lib "${FindBin::Bin}/../lib/mrtg2";
-use locales_mrtg "0.07";
+use locales_mrtg "0.08";
 
 my $LOC = $lang2tran::LOCALE{"brazilian"};
 unlike( &$LOC("The statistics were last updated <strong>Ter&ccedil;a, 26 de Outubro"),

--- a/src/translate/brazilian.pmd
+++ b/src/translate/brazilian.pmd
@@ -31,43 +31,36 @@ return "" unless defined $string;
 
   
   # regexp => replacement string NOTE does not use autovars $1,$2...
-  # charset=iso-2022-jp
 
   %translations =
-  (  
-     #'charset=iso-8859-1'                     => 'charset=iso-8859-1',
-     'Maximal 5 Minute Incoming Traffic'      => 'Tr&aacute;fego M&aacute;ximo de Entrada em 5 minutos',
-     'Maximal 5 Minute Outgoing Traffic'      => 'Tr&aacute;fego M&aacute;ximo de Sa&iacute;da em 5 minutos',
-     'the device'                             => 'dispositivo',
-     'The statistics were last updated (.*)'  => '&Uacute;ltima atualiza&ccedil;&atilde;o das estat&iacute;sticas: $1',
-     ' Average\)'                             => ' - m&eacute;dia)',
-     'Average'                                => 'M&eacute;dia',
-     'Max'                                    => 'M&aacute;x',
-     'Current'                                => 'Atual',
-     'version'                                => 'vers&atilde;o',
-     '`Daily\' Graph \((.*) Minute'           => 'Gr&aacute;fico `Di&aacute;rio\' ($1 minutos',
-     '`Weekly\' Graph \(30 Minute'            => 'Gr&aacute;fico `Semanal\' (30 minutos' ,
-     '`Monthly\' Graph \(2 Hour'              => 'Gr&aacute;fico `Mensal\' (2 horas',
-     '`Yearly\' Graph \(1 Day'                => 'Gr&aacute;fico `Anual\' (1 dia', 
-     'Incoming Traffic in (\S+) per Second'   => 'Tr&aacute;fego de Entrada em $1 por segundo',
-     'Outgoing Traffic in (\S+) per Second'   => 'Tr&aacute;fego de Sa&iacute;da em $1 por segundo',
-     'at which time (.*) had been up for(.*)' => 'nesta hora $1 estava ativo por $2',
-     # '([kMG]?)([bB])/s'                     => '\$1\$2/s',
-     # '([kMG]?)([bB])/min'                   => '\$1\$2/min',
-     # '([kMG]?)([bB])/h'                     => '$1$2/t',
-     # 'Bits'                                 => 'Bits',
-     # 'Bytes'                                => 'Bytes'
-     'In'                                     => 'Entr.',
-     'Out'                                    => 'Sa&iacute;',
-     'Percentage'                             => 'Porc.',
-     'Ported to OpenVMS Alpha by'             => 'Adaptado para o Alpha OpenVMS por', 
-     'Ported to WindowsNT by'                 => 'Adaptado para o WindowsNT por',
-     'and'                                    => 'e',
+  (
+     '^Maximal 5 Minute Incoming Traffic'      => 'Tr&aacute;fego M&aacute;ximo de Entrada em 5 minutos',
+     '^Maximal 5 Minute Outgoing Traffic'      => 'Tr&aacute;fego M&aacute;ximo de Sa&iacute;da em 5 minutos',
+     '^the device'                             => 'dispositivo',
+     '^The statistics were last updated (.*)'  => '&Uacute;ltima atualiza&ccedil;&atilde;o das estat&iacute;sticas: $1',
+     '^ Average\)'                             => ' - m&eacute;dia)',
+     '^Average$'                               => 'M&eacute;dia',
+     '^Max$'                                   => 'M&aacute;x',
+     '^Current'                                => 'Atual',
+     '^version'                                => 'vers&atilde;o', #
+     '^`Daily\' Graph \((.*) Minute'           => 'Gr&aacute;fico `Di&aacute;rio\' ($1 minutos',
+     '^`Weekly\' Graph \(30 Minute'            => 'Gr&aacute;fico `Semanal\' (30 minutos' ,
+     '^`Monthly\' Graph \(2 Hour'              => 'Gr&aacute;fico `Mensal\' (2 horas',
+     '^`Yearly\' Graph \(1 Day'                => 'Gr&aacute;fico `Anual\' (1 dia', 
+     '^Incoming Traffic in (\S+) per Second'   => 'Tr&aacute;fego de Entrada em $1 por segundo',
+     '^Outgoing Traffic in (\S+) per Second'   => 'Tr&aacute;fego de Sa&iacute;da em $1 por segundo',
+     '^at which time (.*) had been up for(.*)' => 'nesta hora $1 estava ativo por $2',
+     '^In$'                                    => 'Entr.',
+     '^Out$'                                   => 'Sa&iacute;',
+     '^Percentage'                             => 'Porc.',
+     '^Ported to OpenVMS Alpha by'             => 'Adaptado para o Alpha OpenVMS por', 
+     '^Ported to WindowsNT by'                 => 'Adaptado para o WindowsNT por',
+     '^and'                                    => 'e',
      '^GREEN'                                  => 'VERDE',
-     'BLUE'                                   => 'AZUL',
-     'DARK GREEN'                             => 'VERDE ESCURO',
-     'MAGENTA'                                => 'LIL&Aacute;S',
-     'AMBER'                                  => 'AMBAR'
+     '^BLUE'                                   => 'AZUL',
+     '^DARK GREEN'                             => 'VERDE ESCURO',
+     '^MAGENTA'                                => 'LIL&Aacute;S',
+     '^AMBER'                                  => 'AMBAR'
   );
 
 # maybe expansions with replacement of whitespace would be more appropriate

--- a/src/translate/skeleton.pm0
+++ b/src/translate/skeleton.pm0
@@ -43,7 +43,7 @@ use strict;
 use vars qw(@ISA @EXPORT $VERSION);
 use Exporter;
 
-$VERSION = '0.07';
+$VERSION = '0.08';
 
 @ISA = qw(Exporter);
 


### PR DESCRIPTION
This PR fixes issue #74.

run the following command to test.

```bash
$ cd src
$ prove
```

## Changes

**BOLD**: difference from previous commit(3e7970a).

src/t/translation.t(new file) 
- You may need to run several times to reproduce.  Because the issue depends on hash order.

src/lib/mrtg2/locales_mrtg.pm
- **not changed**

**translate/skelton.pm0**
- Increase version number(0.08 <- 0.07) 

**translate/brazilian.pmd** 
- Change the regular expressions

src/bin/mrtg
- Increase module locales_mrtg version number(0.08 <- 0.07) 

.github/workflows/build-linux.yml
- Add unit testing

