### PR TITLE
IOS Version check for 10.x and 11.x no longer needed

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,7 +19,7 @@ jobs:
     - name: install_dependencies
       run: |
            sudo apt-get update
-           sudo apt-get remove -yq libgd3
+           sudo apt-get remove -yq libgd3 nginx
            sudo apt-get install -yq libgd-dev libpng-dev zlib1g-dev
     - name: build_and_install
       run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,7 +19,8 @@ jobs:
     - name: install_dependencies
       run: |
            sudo apt-get update
-           sudo apt-get install libgd-dev libpng-dev zlib1g-dev
+           sudo apt-get remove -yq libgd3
+           sudo apt-get install -yq libgd-dev libpng-dev zlib1g-dev
     - name: build_and_install
       run: |
            cd src

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install_dependencies
-      run: sudo apt install libgd-dev libpng-dev zlib1g-dev
+      run: |
+           sudo apt-get update
+           sudo apt-get install libgd-dev libpng-dev zlib1g-dev
     - name: build_and_install
       run: |
            cd src

--- a/src/CHANGES
+++ b/src/CHANGES
@@ -6,6 +6,10 @@ From: youpong
 * drop locales_mrtg.pm, mrtglib.3 and symlinks.
 * 'make clean' removes all generated files.
 
+From: nistorj
+* Removed checks for Cisco IOS versions 10.x and 11.x which conflicts with NXOS checking.
+  We automatically push variables: ifAlias, vmVlan, vlanTrunkPortDynamicStatus if vendor is Cisco. (issue #93)
+
 Changes 2.17.10, 2022-01-19
 ---------------------------
 From: tobi

--- a/src/bin/cfgmaker
+++ b/src/bin/cfgmaker
@@ -170,11 +170,8 @@ sub InterfaceInfo($$$$$) {
 
     my $snmphost = v4onlyifnecessary($router, $routers->{$router}{ipv4only});
 
-    if ($routers->{$router}{deviceinfo}{Vendor} eq 'cisco' &&
-        $routers->{$router}{deviceinfo}{sysDescr} =~ m/Version\s+(\d+\.\d+)/) {
-        push @Variables,  ($1 > 11.0 or $1 < 10.0 ) ? "ifAlias" : "CiscolocIfDescr";
-        if ($1 > 11.2) {push @Variables, "vmVlan";};
-       if ($1 > 11.3) {push @Variables, "vlanTrunkPortDynamicStatus";};
+    if ($routers->{$router}{deviceinfo}{Vendor} eq 'cisco') {
+        push @Variables,  ("ifAlias", "vmVlan", "vlanTrunkPortDynamicStatus");
     } elsif ( $routers->{$router}{deviceinfo}{Vendor} =~ /(?:hp|juniper|dlink|wwp|foundry|dellLan|force10|3com|extremenetworks|openBSD|arista|enterasys|zyxel|vyatta|dcn|brocade|datacom|alcatel|mikrotik|huawei|eltex)/i) {
         push @Variables, "ifAlias";
     }


### PR DESCRIPTION
Cisco IOS version 10.x and 11.x have been retired for some time now. The check is no longer required and conflicts with NXOS Operating system versions which have recently been released (10.2 for example).

This has been tested on:
Catalyst 6500 version 12.2
Catalyst 6500 version 15.5
Catalyst 9300 version 17.6
Nexus 9k NXOS 10.2(3)F.

No errors or incorrect output has been noticed in this environment.
