### PR TITLE
Include <strings.h> header file 

### DIFF
--- a/src/src/rateup.c
+++ b/src/src/rateup.c
@@ -32,12 +32,14 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 /* VC++ does not have unistd.h */
 #ifndef WIN32
 #ifndef NETWARE
 #include "../config.h"
 #endif
+#endif
+#ifdef HAVE_STRINGS_H
+#include <strings.h>
 #endif
 #include <unistd.h>
 #include <sys/types.h>

--- a/src/src/rateup.c
+++ b/src/src/rateup.c
@@ -32,6 +32,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 /* VC++ does not have unistd.h */
 #ifndef WIN32
 #ifndef NETWARE


### PR DESCRIPTION
## Description 

Include the <strings.h> header file containing the strncasecmp() declaration.

## Related Issue

#99 

