### PR TITLE
configure.ac: Avoid implicit declaration of the exit function

### DIFF
--- a/src/CHANGES
+++ b/src/CHANGES
@@ -1,3 +1,5 @@
+* Future C compilers are likely to reject implicit function declarations by default. This language feature was officially removed in 1999. @ffwmeier-rh
+
 Changes 2.17.11, 2022-??-??
 ---------------------------
 From: youpong

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -37,7 +37,7 @@ AC_CACHE_VAL(mr_cv_long_long_format_specifier,[
                 char buffer[1000];
                 sprintf (buffer, "%${format}u", a);
                 sscanf (buffer, "%${format}u", &b);
-                exit (b!=a);
+                return b!=a;
             }
             ]])],[mr_cv_long_long_format_specifier="%${format}d"
             mr_cv_long_long_format="${format}d"


### PR DESCRIPTION
Future C compilers are likely to reject implicit function declarations by default.  This language feature was officially removed in 1999.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
