### PR TITLE
Added ubiquiti as a vendor with its ID

### DIFF
--- a/src/CHANGES
+++ b/src/CHANGES
@@ -1,3 +1,5 @@
+From: @BaptisteRichard
+* add ubiquity oids to cfgmake
 From: tobi
 * fix noHC detection in cfgmaker (interfaces with traffic counter = 0 could still be valid)
 

--- a/src/bin/cfgmaker
+++ b/src/bin/cfgmaker
@@ -172,7 +172,7 @@ sub InterfaceInfo($$$$$) {
 
     if ($routers->{$router}{deviceinfo}{Vendor} eq 'cisco') {
         push @Variables,  ("ifAlias", "vmVlan", "vlanTrunkPortDynamicStatus");
-    } elsif ( $routers->{$router}{deviceinfo}{Vendor} =~ /(?:hp|juniper|dlink|wwp|foundry|dellLan|force10|3com|extremenetworks|openBSD|arista|enterasys|zyxel|vyatta|dcn|brocade|datacom|alcatel|mikrotik|huawei|eltex)/i) {
+    } elsif ( $routers->{$router}{deviceinfo}{Vendor} =~ /(?:hp|juniper|dlink|wwp|foundry|dellLan|force10|3com|extremenetworks|openBSD|arista|enterasys|zyxel|vyatta|dcn|brocade|datacom|alcatel|mikrotik|huawei|eltex|ubiquiti)/i) {
         push @Variables, "ifAlias";
     }
 
@@ -1015,7 +1015,11 @@ sub DeviceInfo ($$$) {
             '1.3.6.1.4.1.14988.' =>     'mikrotik',
             '1.3.6.1.4.1.6486.' =>      'alcatel',
             '1.3.6.1.4.1.2011.' =>      'huawei',
-            '1.3.6.1.4.1.35265.' =>     'eltex'
+            '1.3.6.1.4.1.35265.' =>     'eltex',
+            '1.3.6.1.4.1.4413' =>       'ubiquiti',
+            '1.3.6.1.4.1.41112' =>      'ubiquiti'
+
+
         );
         $DevInfo{Vendor} = 'Unknown Vendor - '.$DevInfo{sysObjectID};
         foreach (keys %vendorIDs) {


### PR DESCRIPTION
I have switches and FW from ubiquiti and they were not recognized as such by cfgmaker. These 2 changes allow me to pull the interface description out of cfgmaker and I think they might benefit other users as well